### PR TITLE
Fixed missing column aggregate_id in migration script for eventlog table

### DIFF
--- a/server/migrations/20161126135901-add-event-log.js
+++ b/server/migrations/20161126135901-add-event-log.js
@@ -18,7 +18,8 @@ exports.up = function(db,callback) {
   db.createTable('eventlog', {
     timestamp:{ type:'datetime'},
     id: { type: 'string', primaryKey: true },
-    json: 'string'
+    json: 'string',
+    aggregate_id: { type: 'string' }
   }, callback);};
 
 exports.down = function(db) {


### PR DESCRIPTION
Virtist sem 'aggregate_id' dálkinn vantaði í eventlog töfluna þegar ég reyndi að keyra uppfærðu útgáfuna